### PR TITLE
Add html coverage report

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ coverage:
 	$(MAKE) start-anvil > /dev/null &
 	sleep 4 # needed to wait for anvil setup to finish
 	cargo llvm-cov --lcov --output-path lcov.info --ignore-filename-regex='fireblocks/' --workspace
+	cargo llvm-cov report --html --ignore-filename-regex='fireblocks/'
 	docker stop anvil
 
 deps:


### PR DESCRIPTION
Modified the Makefile so that the `coverage` target generates an html report.